### PR TITLE
Comment out seal lines

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,6 +22,7 @@ Imports:
     magrittr (>= 1.5),
     purrr (>= 0.2.4),
     rlang (>= 0.2.0),
+    rstudioapi (>= 0.7),
     styler (>= 1.0.0),
     tibble (>= 1.4.2),
     tidyr (>= 0.8.0)

--- a/R/put.R
+++ b/R/put.R
@@ -1,0 +1,53 @@
+#' Put seal
+#'
+#' @noRd
+mask_candidate_lines <- function(context) {
+  # nocov start
+  which_lines_candidate <-
+    grep("(design_|transcribe)", context$contents, value = FALSE)
+
+  grep("(design_|transcribe)", context$contents, value = TRUE) %>%
+    purrr::set_names(which_lines_candidate) %>%
+    gsub("#.+", "", .) %>%
+    grep("\"", ., value = TRUE, invert = TRUE) %>%
+    grep(".+", ., value = TRUE) %>%
+    names() %>%
+    as.numeric()
+  # nocov end
+}
+
+#' @noRd
+put <- function(all = FALSE) {
+  # nocov start
+  context <-
+    rstudioapi::getSourceEditorContext()
+
+  is_console <-
+    grepl("#console", rstudioapi::getActiveDocumentContext()$id)
+
+  which_lines <-
+    mask_candidate_lines(context)
+
+  if (rlang::is_false(all)) {
+    which_lines <-
+      which_lines[which_lines %in% (as.numeric(context$selection[[1]]$range$start[1]) - 1)]
+  }
+
+  x <-
+    tibble::data_frame(line = which_lines,
+                      nline = 1) %>%
+    dplyr::mutate(
+      check_pipe = purrr::pmap_lgl(., ~ context$contents[c(..1)] %>%
+                                     purrr::map_lgl(
+                                       ~ !grepl("(design_|transcribe)\\(.+\\|(TRUE|FALSE))|(%>%|%<>%)",
+                                                x = ..1)))) %>%
+    dplyr::mutate(nline = purrr::pmap_int(.,
+                                          ~ dplyr::if_else(rlang::is_true(..3),
+                                                           2L,
+                                                           1L)))
+
+  out_lines <- unique(c(x$line, x$line - (x$nline - 1)))
+
+  purrr::walk(out_lines, ~ rstudioapi::insertText(c(..1, 1), "# ", id = context$id))
+  # nocov end
+}

--- a/R/put.R
+++ b/R/put.R
@@ -51,3 +51,8 @@ put <- function(all = FALSE) {
   purrr::walk(out_lines, ~ rstudioapi::insertText(c(..1, 1), "# ", id = context$id))
   # nocov end
 }
+
+#' @noRd
+put_all <- function() {
+  put(all = TRUE)
+}

--- a/R/put.R
+++ b/R/put.R
@@ -30,7 +30,7 @@ put <- function(all = FALSE) {
 
   if (rlang::is_false(all)) {
     which_lines <-
-      which_lines[which_lines %in% (as.numeric(context$selection[[1]]$range$start[1]) - 1)]
+      max(which_lines[0 > (which_lines - (as.numeric(context$selection[[1]]$range$start[1])))])
   }
 
   x <-

--- a/R/seal.R
+++ b/R/seal.R
@@ -7,6 +7,8 @@
 #' @param clip If *TRUE* will overwrite the system clipboard.
 #' When clipr is not available, The clip arguments is forcibly *FALSE*.
 #' @param ts include comments that timestamp?
+#' @param mask_seal Whether to comment out after executing the function.
+#' Default *FALSE*. This option is effective only when using RStudio.
 #'
 #' @name seal
 #' @examples
@@ -21,7 +23,7 @@ NULL
 
 #' @rdname seal
 #' @export
-seal <- function(test, load_testthat = FALSE, clip = TRUE, ts = TRUE) {
+seal <- function(test, load_testthat = FALSE, clip = TRUE, ts = TRUE, mask_seal = FALSE) {
 
   test_char <- test
 
@@ -49,6 +51,10 @@ seal <- function(test, load_testthat = FALSE, clip = TRUE, ts = TRUE) {
                  sep = "\n") %>%
       styler::style_text()
   }
+
+  if (rlang::is_true(rstudioapi::isAvailable()))
+    if (rlang::is_true(mask_seal))
+      put(all = FALSE)
 
   return(res)
 }

--- a/inst/rstudio/addins.dcf
+++ b/inst/rstudio/addins.dcf
@@ -1,0 +1,4 @@
+Name: Mask to all seal
+Description: Comment out the lines of transcribe() and design_*() in the document
+Binding: put_all
+Interactive: false

--- a/man/design.Rd
+++ b/man/design.Rd
@@ -55,6 +55,8 @@ design_obj_size(x, ...)
   \item{clip}{If \emph{TRUE} will overwrite the system clipboard.
 When clipr is not available, The clip arguments is forcibly \emph{FALSE}.}
   \item{ts}{include comments that timestamp?}
+  \item{mask_seal}{Whether to comment out after executing the function.
+Default \emph{FALSE}. This option is effective only when using RStudio.}
 }}
 
 \item{environment}{which environment (work space) to search the available objects}

--- a/man/seal.Rd
+++ b/man/seal.Rd
@@ -5,7 +5,8 @@
 \alias{seal}
 \title{Sealing the test results}
 \usage{
-seal(test, load_testthat = FALSE, clip = TRUE, ts = TRUE)
+seal(test, load_testthat = FALSE, clip = TRUE, ts = TRUE,
+  mask_seal = FALSE)
 }
 \arguments{
 \item{test}{test}
@@ -16,6 +17,9 @@ seal(test, load_testthat = FALSE, clip = TRUE, ts = TRUE)
 When clipr is not available, The clip arguments is forcibly \emph{FALSE}.}
 
 \item{ts}{include comments that timestamp?}
+
+\item{mask_seal}{Whether to comment out after executing the function.
+Default \emph{FALSE}. This option is effective only when using RStudio.}
 }
 \description{
 Recording the state of the object

--- a/man/transcribe.Rd
+++ b/man/transcribe.Rd
@@ -22,6 +22,8 @@ If you chose \emph{TRUE}, to make a detailed record for each variables in data f
   \item{clip}{If \emph{TRUE} will overwrite the system clipboard.
 When clipr is not available, The clip arguments is forcibly \emph{FALSE}.}
   \item{ts}{include comments that timestamp?}
+  \item{mask_seal}{Whether to comment out after executing the function.
+Default \emph{FALSE}. This option is effective only when using RStudio.}
 }}
 }
 \description{

--- a/tests/testthat/test-design.R
+++ b/tests/testthat/test-design.R
@@ -9,7 +9,7 @@ test_that("control transcript behavior functions", {
   expect_equal(
     capture_output({
       design_nrow(mtcars, seal = TRUE,
-                  load_testthat = TRUE, ts = FALSE, clip = FALSE)
+                  load_testthat = TRUE, ts = FALSE, clip = FALSE, mask_seal = FALSE)
     },
     print = TRUE, width = 80),
     "library(testthat)\nexpect_equal(\n  nrow(mtcars),\n  32L\n)"


### PR DESCRIPTION
# Summary

As an option of the sealr package.
Added a function to comment out the target line after recording the state of the object (*mask_seal* argument. Default *FALSE*).

- [x] Comment out after `transcribe()` and `design_*()` which row with current cursor.
- [x] Rstudio addins targeting everything in the document

# Demonstration

![ej8bbt7q1k](https://user-images.githubusercontent.com/228649/38159200-87089f4c-34de-11e8-9d9b-2773c0ca74eb.gif)

# GitHub issues fixed

- 🚫 #13 