### PR TITLE
Update DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ Imports:
     purrr (>= 0.2.4),
     rlang (>= 0.2.0),
     rstudioapi (>= 0.7),
-    styler (>= 1.0.0),
+    styler (>= 1.0.2),
     tibble (>= 1.4.2),
     tidyr (>= 0.8.0)
 Suggests: 


### PR DESCRIPTION
styler `v1.0.2` is now available on CRAN and I suggest to add a minimal version dependency to sealr to import this version. Most notable fixes (including critical fixes like implicit dependency removal) were already present in a prior release `v1.0.1`, but currently, sealr does only require the initial release. You can find the changelog [here](http://styler.r-lib.org/news/index.html).